### PR TITLE
fix: respect show/hide settings and prevent widget stretching (#11)

### DIFF
--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -185,11 +185,11 @@ export const MirroredIndicatorButton = GObject.registerClass(
                             this.add_child(container);
                         } else {
                             // For other indicators, use clone approach
-                            // Container is FILL to get full-height hover, but clone inside is centered
+                            // Container is centered to prevent clone from stretching
                             const container = new St.BoxLayout({
                                 style_class: sourceChild.get_style_class_name() || 'panel-status-menu-box',
-                                y_align: Clutter.ActorAlign.FILL,
-                                y_expand: true,
+                                y_align: Clutter.ActorAlign.CENTER,
+                                y_expand: false,
                             });
                             this._createSimpleClone(container, sourceChild);
                             this.add_child(container);


### PR DESCRIPTION
## Summary

Fixes #11 — widgets disabled in settings still appearing on secondary monitors, visual stretching of mirrored indicators, and improved compatibility with theming extensions.

- **Settings-ignored widgets:** `_cloneAllMainPanelIndicators()` now checks `show-activities`, `show-date-time`, and `show-app-menu` settings before mirroring indicators. Previously, every `_updatePanel()` cycle (triggered by session mode changes, extension loads, and delayed timeouts) would re-create indicators the user had disabled. `_hideIndicators()` also now covers all `statusArea` entries instead of only the hardcoded `appMenu`.
- **Widget stretching:** Clone containers for generic indicators changed from `y_align: FILL` / `y_expand: true` to `y_align: CENTER` / `y_expand: false`, preventing `Clutter.Clone` from being stretched vertically to fill the full panel height.
- **Theming compatibility:** `_syncPanelStyle()` now clears inline background styles when the main panel's background alpha is 0 (transparent), so theming extensions can style the secondary panel via CSS.

### Note on Blur My Shell

Our changes remove the inline style conflict that blocked theming, but **Blur My Shell itself only targets `Main.panel`** and has no mechanism to discover secondary panel actors. Full blur support on secondary monitors would require Blur My Shell to also recognize additional panels — that's outside the scope of this extension.

## Test plan

- [ ] Enable extension with 2+ monitors on GNOME 49
- [ ] Disable "Show Activities" in settings → verify it stays hidden on secondary monitor (wait 10+ seconds to confirm `_updatePanel()` cycles don't bring it back)
- [ ] Disable "Show DateTime" in settings → verify clock disappears from secondary monitor
- [ ] Disable "Show AppMenu" in settings → verify app menu disappears
- [ ] Re-enable each setting → verify widgets reappear correctly
- [ ] Verify indicators on secondary monitor are not visually stretched
- [ ] Install Blur My Shell → verify secondary panel doesn't show a solid opaque bar when main panel is transparent

**Please double-test these scenarios** — the `_updatePanel()` re-creation bug is timing-dependent (extension watcher fires at 1s, 2s, 3s, 5s, 8s after init), so disabled widgets may take several seconds to incorrectly reappear on the current version.