### PR TITLE
Remove blur-my-shell integration to have it directly in blur-my-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An updated fork of [spin83/multi-monitors-add-on](https://github.com/spin83/mult
 | **Mirrored indicators** | Any status-area indicator (Vitals, GSConnect, etc.) can be transferred to secondary panels |
 | **Indicator exclusion list** | Prevent specific indicators from being transferred (e.g. Fildem) |
 | **Screenshot tools on all monitors** | Clone the screenshot toolbar to every screen, or follow the cursor |
-| **Blur my Shell integration** | Automatically register secondary panels for blur effects |
+| **Blur my Shell integration** | Blur the secondary panels with Blur my Shell |
 | **Overview on extended monitors** | Show App Grid & Search on secondary displays |
 | **Force workspaces on all displays** | Override GNOME's *workspaces-only-on-primary* setting |
 | **Hot corners** | Enable/disable hot corners on all monitors |
@@ -90,7 +90,6 @@ gnome-extensions prefs multi-monitors-bar@frederykabryan
 | Show AppMenu Button | `show-app-menu` | `true` |
 | Show DateTime Menu | `show-date-time` | `true` |
 | Thumbnails Slider Position | `thumbnails-slider-position` | `auto` |
-| Enable Blur my Shell | `enable-blur-my-shell` | `true` |
 | Hot Corners | `enable-hot-corners` | (system default) |
 | Screenshot on All Monitors | `screenshot-on-all-monitors` | `false` |
 | Force Workspaces on All Displays | `force-workspaces-on-all-displays` | `true` |

--- a/mmlayout.js
+++ b/mmlayout.js
@@ -17,7 +17,6 @@ along with this program; if not, visit https://www.gnu.org/licenses/.
 
 import St from 'gi://St';
 import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
 
@@ -123,102 +122,7 @@ export class MultiMonitorsLayoutManager {
 		this.statusIndicatorsController = null;
 		this._layoutManager_updateHotCorners = null;
 		this._changedEnableHotCornersId = null;
-		this._blurMyShellStateChangedId = null;
-		this._workareasChangedBlurId = null;
-		this._blurReRegisterTimeoutId = null;
-		this._blurRetryTimeoutIds = [];
 
-		if (this._settings.get_boolean('enable-blur-my-shell')) {
-			this._setupBlurMyShellWatcher();
-			this._setupWorkareasBlurWatcher();
-		}
-	}
-
-	_setupBlurMyShellWatcher() {
-		try {
-			if (!Main.extensionManager) return;
-
-			this._blurMyShellStateChangedId = Main.extensionManager.connect('extension-state-changed',
-				(manager, extension) => {
-					if (extension.uuid === 'blur-my-shell@aunetx' && this._settings.get_boolean('enable-blur-my-shell')) {
-						this._refreshBlurMyShellIntegration();
-					}
-				}
-			);
-		} catch (e) {
-			console.debug('[Multi Monitors Add-On] Blur watcher setup failed:', String(e));
-		}
-	}
-
-	_refreshBlurMyShellIntegration() {
-		const mmPanelRef = getMMPanelArray();
-		if (mmPanelRef) {
-			for (const panel of mmPanelRef) {
-				if (panel) {
-					this._registerPanelWithBlurMyShell(panel);
-				}
-			}
-		}
-	}
-
-	// Re-register blur after BMS resets on workareas-changed
-	_setupWorkareasBlurWatcher() {
-		try {
-			this._workareasChangedBlurId = global.display.connect('workareas-changed', () => {
-				if (!this._settings.get_boolean('enable-blur-my-shell')) return;
-
-				// Cancel any pending re-registration
-				if (this._blurReRegisterTimeoutId) {
-					GLib.source_remove(this._blurReRegisterTimeoutId);
-					this._blurReRegisterTimeoutId = null;
-				}
-
-				// BMS resets async (disable + setTimeout(enable, 1)), so wait
-				// long enough for BMS to finish its reset and re-enable
-				this._blurReRegisterTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
-					this._refreshBlurMyShellIntegration();
-					this._blurReRegisterTimeoutId = null;
-					return GLib.SOURCE_REMOVE;
-				});
-			});
-		} catch (e) {
-			console.debug('[Multi Monitors Add-On] Workareas blur watcher setup failed:', String(e));
-		}
-	}
-
-	_registerPanelWithBlurMyShell(panel) {
-		try {
-			// Primary access path: BMS exposes itself via global.blur_my_shell
-			let panelBlur = null;
-
-			if (global.blur_my_shell && global.blur_my_shell._panel_blur) {
-				panelBlur = global.blur_my_shell._panel_blur;
-			} else {
-				// Fallback: extension manager lookup
-				const extensionManager = Main.extensionManager;
-				if (!extensionManager) return;
-
-				const blurExt = extensionManager.lookup('blur-my-shell@aunetx');
-				if (!blurExt || blurExt.state !== 1) return;
-
-				// GNOME 45+: stateObj points to the extension instance
-				const blurMyShell = blurExt.stateObj || blurExt;
-				if (!blurMyShell || !blurMyShell._panel_blur) return;
-
-				panelBlur = blurMyShell._panel_blur;
-			}
-
-			if (!panelBlur) return;
-
-			// Use maybe_blur_panel which checks if already blurred
-			if (typeof panelBlur.maybe_blur_panel === 'function') {
-				panelBlur.maybe_blur_panel(panel);
-			} else if (typeof panelBlur.blur_panel === 'function') {
-				panelBlur.blur_panel(panel);
-			}
-		} catch (e) {
-			console.debug('[Multi Monitors Add-On] Blur integration failed:', String(e));
-		}
 	}
 
 	showPanel() {
@@ -306,27 +210,6 @@ export class MultiMonitorsLayoutManager {
 			Main.layoutManager.disconnect(this._monitorsChangedId);
 			this._monitorsChangedId = null;
 		}
-
-		if (this._blurMyShellStateChangedId && Main.extensionManager) {
-			Main.extensionManager.disconnect(this._blurMyShellStateChangedId);
-			this._blurMyShellStateChangedId = null;
-		}
-
-		if (this._workareasChangedBlurId) {
-			global.display.disconnect(this._workareasChangedBlurId);
-			this._workareasChangedBlurId = null;
-		}
-
-		if (this._blurReRegisterTimeoutId) {
-			GLib.source_remove(this._blurReRegisterTimeoutId);
-			this._blurReRegisterTimeoutId = null;
-		}
-
-		// Clean up all pending blur retry timeouts
-		for (const tid of this._blurRetryTimeoutIds) {
-			GLib.source_remove(tid);
-		}
-		this._blurRetryTimeoutIds = [];
 
 		let panels2remove = this._monitorIds.length;
 		for (let i = 0; i < panels2remove; i++) {
@@ -422,23 +305,6 @@ export class MultiMonitorsLayoutManager {
 			mmPanelRef.push(panel);
 		}
 		this.mmPanelBox.push(mmPanelBox);
-
-		if (this._settings.get_boolean('enable-blur-my-shell')) {
-			// Register with increasing delays to outlast BMS async reset cycles
-			// BMS resets on workareas-changed (which panel creation triggers),
-			// clearing all blur then re-enabling after 1ms. Longer delays ensure
-			// we re-register after BMS has fully settled.
-			const delays = [500, 2000, 4000, 6000, 10000];
-			for (const delay of delays) {
-				const tid = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
-					this._registerPanelWithBlurMyShell(panel);
-					const idx = this._blurRetryTimeoutIds.indexOf(tid);
-					if (idx >= 0) this._blurRetryTimeoutIds.splice(idx, 1);
-					return GLib.SOURCE_REMOVE;
-				});
-				this._blurRetryTimeoutIds.push(tid);
-			}
-		}
 	}
 
 	_popPanel() {

--- a/prefs.js
+++ b/prefs.js
@@ -66,7 +66,6 @@ class MultiMonitorsPrefsWidget extends Gtk.Grid {
             left: _('On the left'),
             auto: _('Auto')
         });
-        this._addBooleanSwitch(_('Enable Blur my Shell integration.'), 'enable-blur-my-shell');
         this._addSettingsBooleanSwitch(_('Enable hot corners.'), this._desktopSettings, ENABLE_HOT_CORNERS);
         this._addBooleanSwitch(_('Show screenshot tools on all monitors.'), SCREENSHOT_ON_ALL_MONITORS_ID);
         this._addBooleanSwitch(_('Force workspaces on all displays.'), FORCE_WORKSPACES_ON_ALL_DISPLAYS_ID);

--- a/schemas/org.gnome.shell.extensions.multi-monitors-bar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.multi-monitors-bar.gschema.xml
@@ -64,13 +64,6 @@
         menu.</description>
     </key>
 
-    <key name="enable-blur-my-shell" type="b">
-      <default>true</default>
-      <summary>Enable Blur my Shell integration.</summary>
-      <description>Automatically register secondary panels with Blur my Shell extension for blur
-        effects.</description>
-    </key>
-
     <key name="screenshot-on-all-monitors" type="b">
       <default>false</default>
       <summary>Show screenshot tools on all monitors.</summary>


### PR DESCRIPTION
Remove blur-my-shell integration from this extension to have it in blur-my-shell instead (see issue #23, and PR https://github.com/aunetx/blur-my-shell/pull/847 in blur-my-shell).

This can be merged when you want and the changes in blur-my-shell will be included in next release, so it will be transparent to users!