### PR TITLE
fix: add GNOME 50 support and fix click handling on secondary monitors

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
         "46",
         "47",
         "48",
-        "49"
+        "49",
+        "50"
     ],
     "uuid": "multi-monitors-bar@frederykabryan",
     "name": "Multi Monitor Bar",

--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -29,7 +29,12 @@ import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 export const MirroredIndicatorButton = GObject.registerClass(
     class MirroredIndicatorButton extends PanelMenu.Button {
         _init(panel, role) {
-            super._init(0.0, null, false);
+            // dontCreateMenu=true: disables Clutter.ClickGesture added in GNOME 50.
+            // In GNOME 50, PanelMenu.Button uses a ClickGesture instead of vfunc_event
+            // to toggle its menu. With dontCreateMenu=false the gesture is enabled and
+            // toggles the (empty) local menu on every click, interfering with our own
+            // _onButtonPress handler that opens the source indicator's menu.
+            super._init(0.0, null, true);
 
             this._role = role;
             this._panel = panel;


### PR DESCRIPTION
- Add '50' to shell-version in metadata.json
- Pass dontCreateMenu=true in MirroredIndicatorButton to disable Clutter.ClickGesture introduced in GNOME 50. The gesture was toggling the empty local menu on every click, preventing _onButtonPress from opening the source indicator's menu. Backward compatible with GNOME 45-49. (with support of Claude)