### PR TITLE
fix: stretch of systray icon (size sync)

### DIFF
--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -327,11 +327,30 @@ export const MirroredIndicatorButton = GObject.registerClass(
                 return;
             }
 
-            // For regular indicators, use Clutter.Clone (works fine)
+            // Clutter.Clone paints its source scaled to fit the clone's own allocation.
+            // Without sync, clone takes source's preferred size while source gets allocated
+            // a taller box by the panel — causing non-uniform scaling (vertical squish)
+            // that visually reads as horizontal stretch. Sync clone size to source's
+            // actual allocation so scale is always 1:1.
             const clone = new Clutter.Clone({
                 source: source,
+                x_align: Clutter.ActorAlign.CENTER,
                 y_align: Clutter.ActorAlign.CENTER,
+                x_expand: false,
                 y_expand: false,
+            });
+
+            const syncSize = () => {
+                const alloc = source.get_allocation_box();
+                const w = alloc.get_width();
+                const h = alloc.get_height();
+                if (w > 0 && h > 0 && (clone.width !== w || clone.height !== h))
+                    clone.set_size(w, h);
+            };
+            syncSize();
+            const allocId = source.connect('notify::allocation', syncSize);
+            clone.connect('destroy', () => {
+                try { source.disconnect(allocId); } catch (_e) {}
             });
 
             parent.add_child(clone);


### PR DESCRIPTION
<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fixes horizontal-stretch appearance of mirrored panel indicators on secondary monitors (GitHub issue #11). Certain extensions (Logo Menu, Switch Profile, Bluetooth Battery Meter in my setup) appeared visually distorted on the mirrored panel even though the content was correct on the primary panel.</p><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root cause</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Clutter.Clone</code> paints its source <strong>scaled non-uniformly</strong> to fit the clone's own allocation. In <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_createSimpleClone()</code>, the clone was given no explicit size, so it defaulted to the source's <em>preferred</em> size — but on the primary panel the source is <em>allocated</em> a taller box to enable full-height hover. The mismatch produced scale factors like <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">scaleX=1.0, scaleY=0.75</code>, which visually compresses the content vertically and reads as a "horizontal stretch."</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Concrete data captured from my setup:</p>
Extension | Source allocation | Clone allocation | Scale (X, Y)
-- | -- | -- | --
Logo Menu | 16×30 | 18×18 | 1.13, 0.60
Switch Profile | 104×32 | 104×24 | 1.00, 0.75

<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><a href="vscode-webview://0hcrt681tb127eo763vdgr8i0qkp0rr59qbkjjelbqi7aavr9ogh/mirroredIndicatorButton.js" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);"><code style="font-family: monospace; color: rgb(72, 160, 199); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mirroredIndicatorButton.js</code></a> — sync clone size to the source's live allocation inside <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_createSimpleClone()</code>:</p><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Add<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">x_align: CENTER</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">x_expand: false</code><span> </span>on the clone (defensive).</li><li>Call<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">clone.set_size(w, h)</code><span> </span>from the source's<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_allocation_box()</code><span> </span>once at creation, and re-sync on<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">notify::allocation</code>.</li><li>Disconnect the signal on clone destroy to avoid leaks.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This mirrors the pattern already used in <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_createQuickSettingsClone()</code> for the system tray.</p><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test environment</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Distro:<span> </span><strong>CachyOS</strong><span> </span>(Arch-based), kernel<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">7.0.0-1-cachyos</code></li><li><strong>GNOME Shell 50.1</strong>,<span> </span><strong>Wayland</strong><span> </span>session</li><li>Dual monitors, 100% scale on both (bug also reproduced at the original fractional-scaling setup)</li><li>Affected extensions installed and enabled:<ul style="padding-inline-start: 2em;"><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">logomenu@aryan_k</code></li><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">switch-profile@kuba</code></li><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Bluetooth-Battery-Meter@maniacx.github.com</code></li><li>plus<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">appindicator</code><span> </span>extensions (Steam), which were unaffected (they bypass<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Clutter.Clone</code><span> </span>via the static-icon copy path)</li></ul></li></ul>Summary
Fixes horizontal-stretch appearance of mirrored panel indicators on secondary monitors (GitHub issue #11). Certain extensions (Logo Menu, Switch Profile, Bluetooth Battery Meter in my setup) appeared visually distorted on the mirrored panel even though the content was correct on the primary panel.

Root cause
Clutter.Clone paints its source scaled non-uniformly to fit the clone's own allocation. In _createSimpleClone(), the clone was given no explicit size, so it defaulted to the source's preferred size — but on the primary panel the source is allocated a taller box to enable full-height hover. The mismatch produced scale factors like scaleX=1.0, scaleY=0.75, which visually compresses the content vertically and reads as a "horizontal stretch."

Concrete data captured from my setup:

Extension	Source allocation	Clone allocation	Scale (X, Y)
Logo Menu	16×30	18×18	1.13, 0.60
Switch Profile	104×32	104×24	1.00, 0.75
Fix
[mirroredIndicatorButton.js](vscode-webview://0hcrt681tb127eo763vdgr8i0qkp0rr59qbkjjelbqi7aavr9ogh/mirroredIndicatorButton.js) — sync clone size to the source's live allocation inside _createSimpleClone():

Add x_align: CENTER and x_expand: false on the clone (defensive).
Call clone.set_size(w, h) from the source's get_allocation_box() once at creation, and re-sync on notify::allocation.
Disconnect the signal on clone destroy to avoid leaks.
This mirrors the pattern already used in _createQuickSettingsClone() for the system tray.

Test environment
Distro: CachyOS (Arch-based), kernel 7.0.0-1-cachyos
GNOME Shell 50.1, Wayland session
Dual monitors, 100% scale on both (bug also reproduced at the original fractional-scaling setup)
Affected extensions installed and enabled:
logomenu@aryan_k
switch-profile@kuba
Bluetooth-Battery-Meter@maniacx.github.com
plus appindicator extensions (Steam), which were unaffected (they bypass Clutter.Clone via the static-icon copy path)