### PR TITLE
fix: GNOME 50 compatibility (click handling + dynamic-workspaces guard)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
         "46",
         "47",
         "48",
-        "49"
+        "49",
+        "50"
     ],
     "uuid": "multi-monitors-bar@frederykabryan",
     "name": "Multi Monitor Bar",

--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -29,7 +29,11 @@ import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 export const MirroredIndicatorButton = GObject.registerClass(
     class MirroredIndicatorButton extends PanelMenu.Button {
         _init(panel, role) {
-            super._init(0.0, null, false);
+            // dontCreateMenu=true: on GNOME 50 PanelMenu.Button installs a
+            // Clutter.ClickGesture that toggles the default menu, which would
+            // swallow clicks before _onButtonPress can forward them to the
+            // source indicator's real menu. We never use the default menu.
+            super._init(0.0, null, true);
 
             this._role = role;
             this._panel = panel;

--- a/mmoverview.js
+++ b/mmoverview.js
@@ -236,30 +236,16 @@ class MultiMonitorsThumbnailsBoxClass extends St.Widget {
         this._windowDragCancelledId = Main.overview.connect('window-drag-cancelled',
             this._onDragCancelled.bind(this));
 
-        // WorkspaceThumbnail.MUTTER_SCHEMA may not be exported or present
-        // in all GNOME versions. Guard against it and fall back to a
-        // reasonable default schema id string so we don't call
-        // Gio.Settings with `undefined`.
-        // Determine a safe schema id string. Coerce to string to avoid passing
-        // undefined to Gio.Settings accidentally.
-        let mutterSchemaId = (WorkspaceThumbnail && WorkspaceThumbnail.MUTTER_SCHEMA) || 'org.gnome.mutter';
-        if (mutterSchemaId === undefined || mutterSchemaId === null) {
-            mutterSchemaId = 'org.gnome.mutter';
-        }
-        // Ensure it's a string
-        mutterSchemaId = String(mutterSchemaId);
+        // On GNOME 50, WorkspaceThumbnail.MUTTER_SCHEMA can return the
+        // extension's own schema id instead of 'org.gnome.mutter', which
+        // then fails the key lookup below. The mutter schema id is stable,
+        // so we just hardcode it.
+        this._mutterSettings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });
 
-        console.debug('[Multi Monitors Add-On] mmoverview: using mutterSchemaId=' + mutterSchemaId);
-        try {
-            this._mutterSettings = new Gio.Settings({ schema_id: mutterSchemaId });
-        } catch (e) {
-            // If creating Gio.Settings with the mutter schema fails,
-            // fall back to org.gnome.mutter as a last resort
-            this._mutterSettings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });
+        if (this._mutterSettings.settings_schema.has_key('dynamic-workspaces')) {
+            this._changedDynamicWorkspacesId = this._mutterSettings.connect('changed::dynamic-workspaces',
+                this._updateSwitcherVisibility.bind(this));
         }
-
-        this._changedDynamicWorkspacesId = this._mutterSettings.connect('changed::dynamic-workspaces',
-            this._updateSwitcherVisibility.bind(this));
 
         this._monitorsChangedId = Main.layoutManager.connect('monitors-changed', () => {
             this._destroyThumbnails();
@@ -303,7 +289,8 @@ class MultiMonitorsThumbnailsBoxClass extends St.Widget {
         Main.overview.disconnect(this._windowDragEndId);
         Main.overview.disconnect(this._windowDragCancelledId);
 
-        this._mutterSettings.disconnect(this._changedDynamicWorkspacesId);
+        if (this._changedDynamicWorkspacesId)
+            this._mutterSettings.disconnect(this._changedDynamicWorkspacesId);
         Main.layoutManager.disconnect(this._monitorsChangedId);
         global.display.disconnect(this._workareasChangedPortholeId);
         super.destroy();


### PR DESCRIPTION
## Summary

Adds GNOME 50 support with two targeted fixes:

1. **Click handling on secondary monitors** (`mirroredIndicatorButton.js`, `metadata.json`)
   GNOME 50's `PanelMenu.Button` installs a `Clutter.ClickGesture` that toggles its default menu on click. `MirroredIndicatorButton` uses `super._init(0.0, null, false)`, so the base class creates an empty default menu and the new gesture silently toggles it on every click — preventing `_onButtonPress` from forwarding the click to the source indicator's real menu. The visible symptom is that indicators on the secondary panel display correctly but are completely unclickable. Passing `dontCreateMenu=true` disables that path. The class has never used the default menu (it always routes via `_onButtonPress` → source indicator), so the change is backward-compatible with GNOME 45–49.

2. **`dynamic-workspaces` schema guard** (`mmoverview.js`)
   On GNOME 50, `WorkspaceThumbnail.MUTTER_SCHEMA` returns the extension's own schema id instead of `org.gnome.mutter`, so the `changed::dynamic-workspaces` subscription throws every time the Overview is shown. Hardcodes `org.gnome.mutter` (the schema id has been stable since GNOME 3.x) and guards the `connect()` with `settings_schema.has_key()` so future mutter changes degrade gracefully.

## Relationship to #26

Credit to @tasgit — PR #26 identified the same `dontCreateMenu=true` root cause, and this PR uses the same one-line fix.

This PR is intentionally more surgical:

- Applied on top of current `main` (#26 was branched from an older main and carries unintended reverts of Vitals spacing, `connectObject` usage in `mmoverview.js`, `_disconnectIndicatorSignals` signal cleanup, and the `_destroyIndicator` helper).
- Also fixes the GNOME 50 `dynamic-workspaces` schema error, which #26 does not address.
- Does not commit `schemas/gschemas.compiled` (build artifact) or modify `.gitignore` / `reinstall.sh`.
- Two focused commits so either fix can be merged or reverted independently.

Addresses #31.

## Test plan

Tested on Arch Linux, GNOME Shell 50.1, Wayland, dual-monitor setup.

- [x] Clicking each mirrored indicator on the secondary monitor opens the correct menu anchored to that monitor (Quick Settings, Date Menu, Activities, tray icons)
- [x] Primary-monitor panel behavior is unchanged
- [x] Overview on secondary monitor shows workspace thumbnails without `dynamic-workspaces` exceptions in the journal
- [x] No `vfunc_event` recursion in `journalctl --user -b -t gnome-shell`
- [x] Click-and-drag on empty panel area of the secondary monitor still grabs maximized windows (no regression in `_tryDragWindow`)

Haven't tested on GNOME 45–49, but the `dontCreateMenu=true` arg and the mutter schema id are both documented stable across those versions.

[Used Claude Code 🤖]