### PR TITLE
feat: per-monitor taskbar filtering for mirrored third-party taskbars

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,6 +48,110 @@ export let mmLayoutManager = null;
 const DASH_TO_DOCK_SCHEMA = 'org.gnome.shell.extensions.dash-to-dock';
 const DASH_TO_DOCK_MULTI_MONITOR_ID = 'multi-monitor';
 
+// Per-monitor taskbar filtering debug switch (off for releases).
+const MMB_PM_DEBUG = false;
+
+// >>> Per-monitor taskbar filter for the PRIMARY panel <<<
+// The primary monitor has no MMB panel; a third-party taskbar (e.g. Tasks in panel)
+// lives directly in Main.panel. This filter hides Main.panel taskButtons whose window
+// is NOT on the primary monitor. Tasks in panel is never modified: we override
+// visibility at runtime via notify::visible — if it tries to show a button whose window
+// is on another monitor, we hide it again (recursion-safe).
+class PrimaryTaskbarFilter {
+    constructor() {
+        this._watched = new Set();
+        this._scanId = 0;
+        this._scanAndFilter();
+        global.display.connectObject(
+            'window-created', () => this._scheduleScan(),
+            'window-entered-monitor', () => this._scheduleScan(),
+            'window-left-monitor', () => this._scheduleScan(),
+            'grab-op-end', () => this._scheduleScan(),   // drag end → guaranteed re-sync
+            this);
+        global.workspace_manager.connectObject(
+            'active-workspace-changed', () => this._scheduleScan(), this);
+        Main.layoutManager.connectObject('monitors-changed', () => this._scheduleScan(), this);
+    }
+
+    _scheduleScan() {
+        // Trailing-edge debounce: reset the timer on every event so the scan runs once
+        // the drag/burst settles, when get_monitor() is guaranteed correct.
+        if (this._scanId)
+            GLib.source_remove(this._scanId);
+        this._scanId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+            this._scanId = 0;
+            this._scanAndFilter();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    _scanAndFilter() {
+        const statusArea = Main.panel.statusArea;
+        let count = 0;
+        for (const role of Object.keys(statusArea)) {
+            if (!/^taskButton\d+$/.test(role))
+                continue;
+            const tb = statusArea[role];
+            if (!tb)
+                continue;
+            if (!this._watched.has(tb)) {
+                this._watched.add(tb);
+                tb.connectObject('notify::visible', () => this._applyFilter(tb), this);
+                tb.connect('destroy', () => this._watched.delete(tb));
+            }
+            this._applyFilter(tb);
+            count++;
+        }
+        if (MMB_PM_DEBUG)
+            log(`[MMB-FILTER] primary scan: ${count} taskButton`);
+    }
+
+    _applyFilter(tb) {
+        const win = tb?._window;
+        if (!win)
+            return;
+        const primaryIndex = Main.layoutManager.primaryIndex;   // read live (primary can change)
+        let desired = false;
+        try {
+            // Canonical window-list/aztaskbar rule (symmetric with mmpanel _syncTaskbarFilter):
+            // show a window on the primary monitor, hide one elsewhere — decided from the
+            // window's own state, never from the source button's .visible.
+            desired = win.get_monitor() === primaryIndex
+                && !win.skip_taskbar
+                && win.located_on_workspace(global.workspace_manager.get_active_workspace());
+        } catch (_e) {
+            return;   // dangling Meta.Window
+        }
+        // Idempotent and two-way: an earlier one-way version only ever set visible=false,
+        // so a window moved back to the primary monitor stayed hidden (Tasks in panel does
+        // not watch monitor changes). Recursion-safe: if tb.visible already equals desired,
+        // no notify fires and the chain stops.
+        if (tb.visible !== desired)
+            tb.visible = desired;
+    }
+
+    destroy() {
+        if (this._scanId) {
+            GLib.source_remove(this._scanId);
+            this._scanId = 0;
+        }
+        global.display.disconnectObject(this);
+        global.workspace_manager.disconnectObject(this);
+        Main.layoutManager.disconnectObject(this);
+        // Release the taskButtons back to Tasks in panel's own control.
+        for (const tb of this._watched) {
+            try {
+                tb.disconnectObject(this);
+                if (typeof tb._updateVisibility === 'function')
+                    tb._updateVisibility();   // let Tasks in panel restore the correct visibility
+            } catch (_e) {
+            }
+        }
+        this._watched.clear();
+    }
+}
+// <<< PrimaryTaskbarFilter end >>>
+
 export default class MultiMonitorsExtension extends Extension {
 	constructor(metadata) {
 		super(metadata);
@@ -272,6 +376,9 @@ export default class MultiMonitorsExtension extends Extension {
 		this._mu_settings = new Gio.Settings({ schema: MUTTER_SCHEMA });
 		this._applyMainPanelClipping();
 
+		// Per-monitor taskbar filter for the primary panel.
+		this._pmTaskbarFilter = new PrimaryTaskbarFilter();
+
 		this._switchOffThumbnailsMuId = this._mu_settings.connect('changed::' + WORKSPACES_ONLY_ON_PRIMARY_ID,
 			this._switchOffThumbnails.bind(this));
 		this._forceWorkspacesId = this._settings.connect('changed::force-workspaces-on-all-displays', () => {
@@ -481,6 +588,10 @@ export default class MultiMonitorsExtension extends Extension {
 	disable() {
 		// Unpatch screenshot UI
 		ScreenshotPatch.unpatchScreenshotUI();
+
+		// Tear down the primary taskButton filter (return taskButtons to Tasks in panel).
+		this._pmTaskbarFilter?.destroy();
+		this._pmTaskbarFilter = null;
 
 		if (this._prepareForSleepId) {
 			try {

--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -25,6 +25,9 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
 
+// YOL 5 per-monitor taskButton filtreleme — debug log anahtari (Faz 4'te false yapilacak).
+const MMB_PM_DEBUG = false;
+
 const MMWorkspacePreviewLayout = GObject.registerClass(
     class MMWorkspacePreviewLayout extends Clutter.LayoutManager {
         vfunc_get_preferred_width() {
@@ -185,6 +188,13 @@ export const MirroredIndicatorButton = GObject.registerClass(
             this._sourceIndicator = Main.panel.statusArea[role] || null;
             this._isEmpty = false;
 
+            // >>> FILTRE-A (YOL 5): taskButton isaretle. Klon HER ZAMAN tam olusturulur
+            // (icerik + box); gorunurluk _syncMirrorPresence guard + _syncTaskbarFilter ile
+            // yonetilir. (Early-return KALDIRILDI — bos-klon bug'i: pencere sonradan gelince
+            // gorunur yapilsa da Clutter.Clone icerigi olusturulmamis kaliyordu.) <<<
+            if (this._isTaskButtonRole(role))
+                this._isTaskButtonClone = true;
+
             if (this._sourceIndicator) {
                 // Check if the source indicator has any visible content
                 const sourceChild = this._sourceIndicator.get_first_child();
@@ -227,6 +237,38 @@ export const MirroredIndicatorButton = GObject.registerClass(
             this.track_hover = false;
         }
 
+        // >>> YOL 5 per-monitor taskButton filtre yardimcilari <<<
+        _isTaskButtonRole(role) {
+            // tasks-in-panel format: `taskButton${windowId}` (extension.js:424), windowId pozitif int.
+            // Kati regex — gelecekteki 'taskButtonGroup' gibi roller yanlis-pozitif vermesin.
+            return typeof role === 'string' && /^taskButton\d+$/.test(role);
+        }
+
+        _getTaskButtonWindow() {
+            // TaskButton._window addToStatusArea ONCESI set → klon gorunurken _window dolu.
+            const src = this._sourceIndicator;
+            if (!src)
+                return null;
+            const win = src._window;
+            return (win && typeof win.get_monitor === 'function') ? win : null;
+        }
+
+        _shouldShowTaskButton() {
+            const win = this._getTaskButtonWindow();
+            if (!win)
+                return false;                    // _window yok/dangling → guvenli default: gizle
+            let mon = -1;
+            try {
+                mon = win.get_monitor();         // dangling Meta.Window guard
+            } catch (_e) {
+                return false;
+            }
+            if (mon < 0)
+                return false;                    // monitor henuz atanmamis (gecis ani)
+            return mon === this._panel.monitorIndex; // _panel monitorIndex (mmpanel.js:337)
+        }
+        // <<< filtre yardimcilari bitti >>>
+
         _setupSourcePresenceWatchers() {
             if (this._sourcePresenceSignals)
                 return;
@@ -266,6 +308,13 @@ export const MirroredIndicatorButton = GObject.registerClass(
                 this._markEmpty();
                 return;
             }
+
+            // >>> FILTRE-B guard (YOL 5): taskButton gorunurlugu SADECE _syncTaskbarFilter'da
+            // (window-entered/left-monitor → tum paneller). _syncMirrorPresence kaynak-allocation
+            // spam'i ile tetiklenir; surukleme sirasinda get_monitor()=-1 geçiş-ani okuyup klonu
+            // yanlis gizliyordu. taskButton'a DOKUNMA → yaris kosulu cozulur. <<<
+            if (this._isTaskButtonClone)
+                return;
 
             const sourceChild = this._sourceIndicator.get_first_child?.();
             const hasContent = this._sourceIndicator.visible &&
@@ -1179,7 +1228,16 @@ export const MirroredIndicatorButton = GObject.registerClass(
             const forwardSpec = (eventName, vfuncName, event) => {
                 let handled = false;
 
-                if ((eventName === 'button-press-event' || eventName === 'touch-event') && (targetChild.menu || targetChild._menu)) {
+                // BUG FIX (taskButton sol-tik davranisi): Astra Monitor menu-acma workaround'u SADECE
+                // menu-merkezli indicator'lar (Astra gibi) icindir. tasks-in-panel TaskButton bir
+                // PanelMenu.Button (default bos .menu var) ama tiklamayi button-RELEASE ile
+                // pencere-aktive/minimize olarak isler (tasks-in-panel extension.js:469 → _onClick).
+                // Bu workaround taskButton klonunda button-PRESS'te yanlislikla menu aciyordu → sol-tik
+                // "sag-tik gibi options" gosteriyordu. taskButton klonu icin ATLA → asagidaki normal
+                // forward tasks-in-panel'in kendi sol/sag davranisini calistirir (primary ile ayni).
+                if ((eventName === 'button-press-event' || eventName === 'touch-event')
+                    && !this._isTaskButtonClone
+                    && (targetChild.menu || targetChild._menu)) {
                     if (this._openAstraProxyMenu(proxy, targetChild)) {
                         return Clutter.EVENT_STOP;
                     }
@@ -2024,6 +2082,29 @@ export const MirroredIndicatorButton = GObject.registerClass(
 
             if (this._role === 'quickSettings' && this._sourceIndicator?.menu) {
                 return this._openQuickSettingsMenu();
+            }
+
+            // BUG FIX (taskButton klonu sol-tik = primary ile AYNI davranis):
+            // Klon kendi PanelMenu.Button _onButtonPress'inden gecer (Astra forwardSpec DEGIL — taskButton
+            // o yola hic girmez). Kaynak TaskButton'in AppMenu'su dolu oldugundan, asagidaki generic dal
+            // (this._sourceIndicator.menu) HER tikta menuyu aciyordu → sol-tik "sag-tik gibi options".
+            // tasks-in-panel primary'de menu-on-press'i vfunc_event no-op ile oldurur ve button-RELEASE'te
+            // _onClick ile sol=aktive/sag=menu yapar. Klonda bunu buton-ayrimli olarak yeniden uretiyoruz:
+            //   sol  → kaynagin _toggleWindow() (pencere aktive/minimize)   [tasks-in-panel extension.js:513-524]
+            //   orta → kaynagin _onClick(event) (yeni pencere)              [extension.js:541-546]
+            //   sag  → asagi dus → _openMirroredMenu (kaynak AppMenu, klona anchor'lu = primary'deki sag-tik)
+            if (this._isTaskButtonClone) {
+                const src = this._sourceIndicator;
+                const button = event?.get_button?.() ?? Clutter.BUTTON_PRIMARY;
+                if (button === Clutter.BUTTON_PRIMARY && src && typeof src._toggleWindow === 'function') {
+                    src._toggleWindow();
+                    return Clutter.EVENT_STOP;
+                }
+                if (button === Clutter.BUTTON_MIDDLE && src && typeof src._onClick === 'function') {
+                    src._onClick(event);
+                    return Clutter.EVENT_STOP;
+                }
+                // SECONDARY (sag) → asagidaki _openMirroredMenu'ye dusur (kaynak AppMenu)
             }
 
             // Check for standard menu first

--- a/mmpanel.js
+++ b/mmpanel.js
@@ -32,6 +32,9 @@ import * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import * as MultiMonitors from './extension.js';
+
+// YOL 5 per-monitor taskButton filtreleme — debug log anahtari (Faz 4'te false).
+const MMB_PM_DEBUG = false;
 import * as MMCalendar from './mmcalendar.js';
 import * as Constants from './mmPanelConstants.js';
 import { StatusIndicatorsController } from './statusIndicatorsController.js';
@@ -405,6 +408,26 @@ const MultiMonitorsPanel = GObject.registerClass(
 
             this._workareasChangedId = global.display.connect('workareas-changed', () => this.queue_relayout());
 
+            // >>> FILTRE-B (YOL 5): pencere monitor degisimi → taskbar re-filter <<<
+            // tasks-in-panel monitor-degisimini DINLEMEZ → bu watcher ZORUNLU.
+            // connectObject(owner=this) → panel destroy'da otomatik disconnect (leak-proof,
+            // mevcut disposed-error baseline'ini cogaltmaz).
+            global.display.connectObject(
+                'window-entered-monitor', (_d, idx, win) => this._onWindowMonitorChanged(idx, win),
+                'window-left-monitor', (_d, idx, win) => this._onWindowMonitorChanged(idx, win),
+                // restacked: pencere stacking/monitor gecisi yerlestikten sonra → idempotent re-filter
+                // (window-list/aztaskbar ayni sinyali dinler; no-op guard sayesinde ucuz).
+                'restacked', () => this._scheduleTaskbarFilterSync(),
+                // grab-op-end: surukleme bitisinde nihai re-sync guvencesi (sinyal kacsa bile).
+                'grab-op-end', () => this._scheduleTaskbarFilterSync(),
+                this);
+
+            // KOK NEDEN #3 FIX: deferred-work (GNOME-native). _scheduleTaskbarFilterSync artik GLib
+            // trailing-timeout DEGIL, Main.queueDeferredWork kullanir → bir sonraki frame'den ONCE bir
+            // kez calisir, surukleme sinyal patlamasini OTOMATIK coalesce eder, 0 lag. Eski 100ms
+            // trailing-debounce surukleme BITENE kadar hic ateslemiyordu (hizli surukleme bug'i).
+            this._taskbarFilterWorkId = Main.initializeDeferredWork(this, () => this._syncTaskbarFilter());
+
             this._showActivitiesId = this._settings.connect('changed::' + SHOW_ACTIVITIES_ID,
                 this._showActivities.bind(this));
             this._showActivities();
@@ -533,6 +556,10 @@ const MultiMonitorsPanel = GObject.registerClass(
                     GLib.source_remove(timeoutId);
                 this._panelRefreshTimeouts = [];
             }
+            // FILTRE-B deferred-work (this._taskbarFilterWorkId) panel destroy'da Main tarafindan
+            // OTOMATIK temizlenir (initializeDeferredWork actor'in 'destroy' sinyaline baglanir) →
+            // manuel source_remove gerekmez. Eski GLib trailing-timeout kaldirildi.
+            this._taskbarFilterWorkId = null;
 
             if (this._workareasChangedId) {
                 global.display.disconnect(this._workareasChangedId);
@@ -1097,6 +1124,20 @@ const MultiMonitorsPanel = GObject.registerClass(
                 this._removeRole(rightIndicators, 'activities');
             }
 
+            // BUG FIX (show-activities ayari extended panelde de onurlanir):
+            // MMB'nin sentetik Activities (workspace-dots) butonu _ensureIndicator('activities') ile
+            // HER _updatePanel'de yeniden yaratiliyordu. _showActivities (mmpanel:612) ayari onurlandirir
+            // ama bu clone pipeline SHOW_ACTIVITIES_ID gate'ini yok sayip onu yeniden yaratiyordu →
+            // show-activities=false ETKISIZ kaliyordu. Cozum (ArcMenu drop ile AYNI pattern, silme yok):
+            // ayar kapaliysa 'activities' rolunu listelerden cikar → desiredRoles disi kalir →
+            // _removeStaleIndicators temizler, _updateBox yeniden yaratmaz.
+            // (Bagimsiz MMB bug'i — per-monitor taskButton filtrelerine HIC dokunmaz.)
+            if (!this._settings.get_boolean(SHOW_ACTIVITIES_ID)) {
+                this._removeRole(leftIndicators, 'activities');
+                this._removeRole(centerIndicators, 'activities');
+                this._removeRole(rightIndicators, 'activities');
+            }
+
             // Now mirror them in order
             const desiredRoles = new Set([...leftIndicators, ...centerIndicators, ...rightIndicators]);
             this._removeStaleIndicators(desiredRoles);
@@ -1104,7 +1145,71 @@ const MultiMonitorsPanel = GObject.registerClass(
             this._updateBox(leftIndicators, this._leftBox);
             this._updateBox(centerIndicators, this._centerBox);
             this._updateBox(rightIndicators, this._rightBox);
+            this._syncTaskbarFilter();   // re-scan sonrasi taskbar per-monitor filtre (FILTRE-B)
         }
+
+        // >>> FILTRE-B (YOL 5) dinamik taskbar filtre metodlari <<<
+        _onWindowMonitorChanged(monitorIndex, metaWin) {
+            // monitorIndex guard KALDIRILDI: her panel HER monitor olayinda kendini sync etsin.
+            // Hizli suruklemede window-entered(hedef) sinyali kacsa/sirasa bile, gelen herhangi
+            // bir window-left/entered olayinda TUM paneller mutlak durumu yeniden hesaplar
+            // (idempotent + no-op guard ucuz). Sinyal-kacirma/sira yarisina dayanikli.
+            const t = metaWin?.get_window_type?.();
+            if (t === Meta.WindowType.NORMAL || t === Meta.WindowType.DIALOG ||
+                t === Meta.WindowType.MODAL_DIALOG || t === Meta.WindowType.SPLASHSCREEN)
+                this._scheduleTaskbarFilterSync();
+        }
+
+        _scheduleTaskbarFilterSync() {
+            // DEFERRED-WORK coalescing (KOK NEDEN #3 FIX). _syncTaskbarFilter bir sonraki frame'den
+            // ONCE bir kez calisir; bir suruklemenin sinyal patlamasi otomatik birlestirilir, 0 lag.
+            // queueDeferredWork yalnizca actor MAPPED iken calisir → panel gizliyken bos islem yapmaz.
+            if (this._taskbarFilterWorkId)
+                Main.queueDeferredWork(this._taskbarFilterWorkId);
+        }
+
+        _syncTaskbarFilter() {
+            // IDEMPOTENT — her cagri mutlak durumu bastan hesaplar (toggle/delta DEGIL).
+            //
+            // KOK NEDEN #1 FIX: shouldShow artik kaynak taskButton'in `.visible`'ina BAGIMLI DEGIL.
+            // Eski kod `&& !!src.visible` kullaniyordu. Ama PrimaryTaskbarFilter (extension.js) primary-
+            // disi pencereler icin Main.panel'deki GERCEK taskButton.visible'i false yapiyor; bu carpan
+            // o gizligi extended klonlara da tasiyordu → pencere extended monitore gidince HICBIR panelde
+            // gorunmuyordu. window-list/aztaskbar kanonik pattern'i: kaynagin gorunurlugunu DEGIL,
+            // pencerenin kendi durumunu (skip_taskbar + aktif workspace + monitor) bagimsiz hesapla.
+            const myMonitor = this.monitorIndex;
+            const activeWs = global.workspace_manager.get_active_workspace();
+            let changed = 0;
+            // Object.keys snapshot — iterasyon sirasinda statusArea mutasyonu (klon
+            // ekle/sil) crash etmesin (edge: pencere kapanma + re-filter yarisi).
+            for (const role of Object.keys(this.statusArea)) {
+                if (!/^taskButton\d+$/.test(role))
+                    continue;
+                const clone = this.statusArea[role];
+                if (!clone)
+                    continue;
+                const win = clone._sourceIndicator?._window;
+                let shouldShow = false;
+                try {
+                    shouldShow = !!win
+                        && !win.skip_taskbar
+                        && win.located_on_workspace(activeWs)
+                        && win.get_monitor() === myMonitor;
+                } catch (_e) {
+                    shouldShow = false;   // dangling Meta.Window → gizle
+                }
+                if (shouldShow === clone.visible)
+                    continue;   // NO-OP guard (visible-based; _isEmpty'e dokunma → box'ta kalir)
+                clone.visible = shouldShow;
+                clone.reactive = shouldShow;
+                clone.can_focus = shouldShow;
+                clone.track_hover = shouldShow;
+                changed++;
+            }
+            if (MMB_PM_DEBUG && changed)
+                log(`[MMB-FILTER] sync panel=${myMonitor} changed=${changed}`);
+        }
+        // <<< FILTRE-B metodlari bitti >>>
 
         _isArcMenuRole(role) {
             if (role !== 'ArcMenu')


### PR DESCRIPTION
## Summary

This adds **per-monitor taskbar filtering** so that a third-party taskbar mirrored by MMB
(specifically [Tasks in panel](https://github.com/fthx/tasks-in-panel) by @fthx) shows **only the
windows that live on each monitor**, instead of every monitor mirroring the same global window list.
This closes the gap described in #35.

It also fixes a small independent baseline bug: the synthetic Activities button was recreated on
extended panels even when `show-activities` was off.

Branched on top of current `main` (commit c9dde8e, v42) — applies cleanly, no conflicts.
Tested on GNOME Shell 49 / Wayland / Fedora 43 / 4 monitors (DisplayLink).

## Motivation (#35)

MMB mirrors the top bar onto every monitor, but a mirrored `taskButton` is a `Clutter.Clone` of the
primary one, so every monitor shows the **same** window list. Users want each monitor's bar to show
its own windows (macOS / Windows per-monitor taskbar behavior).

Tasks in panel registers one independent `addToStatusArea('taskButton' + windowId, …)` entry per
window, so each mirrored clone can be shown/hidden individually — which makes per-monitor filtering
possible **without touching Tasks in panel at all**.

## What changed

Three cooperating, idempotent filters using the canonical `window-list` / `aztaskbar` primitive.
Visibility is always computed from the **window's own state**, never from the source button's
`.visible`:

```js
shouldShow = !win.skip_taskbar
          && win.located_on_workspace(active)
          && win.get_monitor() === panelMonitor
```

- **`mmpanel.js` — `_syncTaskbarFilter()`**: per-extended-panel sweep over `taskButton\d+` clones,
  toggling `.visible`. Scheduled through **`Main.queueDeferredWork`** (next-frame coalescing, no lag)
  on `window-entered/left-monitor`, `restacked`, and `grab-op-end`.
- **`mirroredIndicatorButton.js`**: flags taskButton clones (`_isTaskButtonClone`) and keeps
  `_syncMirrorPresence` from fighting the per-monitor filter; a clone's left-click now reaches Tasks
  in panel's own activate/minimize handler (`_onButtonPress` routes PRIMARY → `_toggleWindow`,
  SECONDARY → mirrored menu) instead of the generic mirrored-menu path.
- **`extension.js` — `PrimaryTaskbarFilter`**: applies the same rule to the real `Main.panel`
  taskButtons on the primary monitor. Idempotent, `notify::visible` recursion-safe, fully torn down
  on `disable()` (returns the buttons to Tasks in panel's control).

### Independent fix: honor `show-activities` on extended panels
`_cloneAllMainPanelIndicators` recreated the synthetic Activities button on every `_updatePanel`,
bypassing the `SHOW_ACTIVITIES_ID` setting. Added a one-line guard using the **same pattern as the
existing ArcMenu activities-drop** just above it, so the setting is respected. Pre-existing behavior,
unrelated to the per-monitor work.

## How it behaves

- Each extended panel shows only its monitor's window buttons; drag a window across monitors and its
  button follows in real time (and reappears on the primary when dragged back).
- The primary panel is filtered the same way.
- **Tasks in panel is not modified** — it stays a stock, auto-updatable extension.

## A question on defaults (toggle vs. always-on)

Right now filtering is **always on**. That changes the existing mirrored-taskbar behavior (global →
per-monitor) for current users. I'm happy to gate it behind a `gschema` key + a prefs switch
(default off, opt-in) if you'd prefer to keep the current default — just let me know which you want
and I'll push that variant. I left it always-on for now to keep the diff focused and easy to review.

## Testing

- `glib-compile-schemas --strict` passes; GJS parse of all three files clean.
- 4-monitor live session (Fedora 43 / GNOME 49 / Wayland / DisplayLink): static placement,
  slow/fast drag, primary↔extended and extended↔extended moves, return-to-primary, left/right/middle
  click.
- Debug logging is gated behind `MMB_PM_DEBUG` (set to `false`).

## Notes for the reviewer

- Filtering is scoped strictly to `/^taskButton\d+$/` — no other indicator or clone is touched.
- Net: **+298 / −1** across `extension.js`, `mmpanel.js`, `mirroredIndicatorButton.js`; nothing else
  changed.
- Full architecture & root-cause write-up available if useful.

Closes #35 (taskbar side). Companion note: fthx/tasks-in-panel#20.
