### PR TITLE
feat: per-monitor taskbar filtering for mirrored third-party taskbars (rebased on current main, cf. #36)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,6 +48,112 @@ export let mmLayoutManager = null;
 const DASH_TO_DOCK_SCHEMA = 'org.gnome.shell.extensions.dash-to-dock';
 const DASH_TO_DOCK_MULTI_MONITOR_ID = 'multi-monitor';
 
+// Per-monitor taskbar filtering debug flag.
+const MMB_PM_DEBUG = false;
+
+// Primary-monitor taskButton per-monitor filter.
+// The primary monitor has no MMB panel; the third-party tasks-in-panel taskbar lives
+// on Main.panel. This filter hides Main.panel taskButtons for windows that are NOT on
+// the primary monitor. tasks-in-panel is left untouched: this is a runtime
+// notify::visible override — whenever tasks-in-panel shows a button whose window is on
+// another monitor, we hide it again (recursion-safe).
+class PrimaryTaskbarFilter {
+    constructor() {
+        this._watched = new Set();
+        this._scanId = 0;
+        this._scanAndFilter();
+        global.display.connectObject(
+            'window-created', () => this._scheduleScan(),
+            'window-entered-monitor', () => this._scheduleScan(),
+            'window-left-monitor', () => this._scheduleScan(),
+            'grab-op-end', () => this._scheduleScan(),   // end of drag -> definitive re-sync
+            this);
+        global.workspace_manager.connectObject(
+            'active-workspace-changed', () => this._scheduleScan(), this);
+        Main.layoutManager.connectObject('monitors-changed', () => this._scheduleScan(), this);
+    }
+
+    _scheduleScan() {
+        // Trailing-edge debounce (same logic as mmpanel _scheduleTaskbarFilterSync):
+        // reset the timer on every event -> the scan runs once the drag STOPS, so
+        // get_monitor() is definitive.
+        if (this._scanId)
+            GLib.source_remove(this._scanId);
+        this._scanId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+            this._scanId = 0;
+            this._scanAndFilter();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    _scanAndFilter() {
+        const statusArea = Main.panel.statusArea;
+        let count = 0;
+        for (const role of Object.keys(statusArea)) {
+            if (!/^taskButton\d+$/.test(role))
+                continue;
+            const tb = statusArea[role];
+            if (!tb)
+                continue;
+            if (!this._watched.has(tb)) {
+                this._watched.add(tb);
+                tb.connectObject('notify::visible', () => this._applyFilter(tb), this);
+                tb.connect('destroy', () => this._watched.delete(tb));
+            }
+            this._applyFilter(tb);
+            count++;
+        }
+        if (MMB_PM_DEBUG)
+            log(`[MMB-FILTER] primary scan: ${count} taskButton`);
+    }
+
+    _applyFilter(tb) {
+        const win = tb?._window;
+        if (!win)
+            return;
+        const primaryIndex = Main.layoutManager.primaryIndex;   // read live (primary can change)
+        let desired = false;
+        try {
+            // Canonical window-list/aztaskbar pattern (symmetric with mmpanel
+            // _syncTaskbarFilter): show a window that lives on the primary monitor, hide
+            // one that does not — computed from the window's own state, never from the
+            // source button's .visible.
+            desired = win.get_monitor() === primaryIndex
+                && !win.skip_taskbar
+                && win.located_on_workspace(global.workspace_manager.get_active_workspace());
+        } catch (_e) {
+            return;   // dangling Meta.Window
+        }
+        // Idempotent, two-way: the old code was one-way (only `tb.visible = false`).
+        // When a window moves back from an extended monitor to the primary it must be
+        // shown again, but it wasn't; since tasks-in-panel doesn't listen for monitor
+        // changes either, the button stayed hidden on the primary.
+        // Recursion-safe: if tb.visible already equals desired, no notify fires -> the chain stops.
+        if (tb.visible !== desired)
+            tb.visible = desired;
+    }
+
+    destroy() {
+        if (this._scanId) {
+            GLib.source_remove(this._scanId);
+            this._scanId = 0;
+        }
+        global.display.disconnectObject(this);
+        global.workspace_manager.disconnectObject(this);
+        Main.layoutManager.disconnectObject(this);
+        // Remove the filter: hand the taskButtons back to tasks-in-panel's control.
+        for (const tb of this._watched) {
+            try {
+                tb.disconnectObject(this);
+                if (typeof tb._updateVisibility === 'function')
+                    tb._updateVisibility();   // tasks-in-panel restores the correct visibility
+            } catch (_e) {
+            }
+        }
+        this._watched.clear();
+    }
+}
+
 export default class MultiMonitorsExtension extends Extension {
 	constructor(metadata) {
 		super(metadata);
@@ -273,6 +379,9 @@ export default class MultiMonitorsExtension extends Extension {
 		this._mu_settings = new Gio.Settings({ schema: MUTTER_SCHEMA });
 		this._applyMainPanelClipping();
 
+		// Primary-monitor taskButton per-monitor filter (see PrimaryTaskbarFilter above)
+		this._pmTaskbarFilter = new PrimaryTaskbarFilter();
+
 		this._switchOffThumbnailsMuId = this._mu_settings.connect('changed::' + WORKSPACES_ONLY_ON_PRIMARY_ID,
 			this._switchOffThumbnails.bind(this));
 		this._forceWorkspacesId = this._settings.connect('changed::force-workspaces-on-all-displays', () => {
@@ -472,6 +581,10 @@ export default class MultiMonitorsExtension extends Extension {
 	disable() {
 		// Unpatch screenshot UI
 		ScreenshotPatch.unpatchScreenshotUI();
+
+		// Remove the primary taskButton filter (hand the taskButtons back to tasks-in-panel)
+		this._pmTaskbarFilter?.destroy();
+		this._pmTaskbarFilter = null;
 
 		if (this._prepareForSleepId) {
 			this._loginManager.disconnect(this._prepareForSleepId);

--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -25,6 +25,9 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
 
+// Per-monitor taskButton filtering debug-log flag.
+const MMB_PM_DEBUG = false;
+
 const MMWorkspacePreviewLayout = GObject.registerClass(
     class MMWorkspacePreviewLayout extends Clutter.LayoutManager {
         vfunc_get_preferred_width() {
@@ -190,6 +193,13 @@ export const MirroredIndicatorButton = GObject.registerClass(
             this._sourceIndicator = Main.panel.statusArea[role] || null;
             this._isEmpty = false;
 
+            // FILTER-A: flag taskButton clones. The clone is ALWAYS fully built
+            // (content + box); visibility is managed by the _syncMirrorPresence guard +
+            // _syncTaskbarFilter. (The early-return was REMOVED — empty-clone bug: a later window
+            // gorunur yapilsa da Clutter.Clone icerigi olusturulmamis kaliyordu.) <<<
+            if (this._isTaskButtonRole(role))
+                this._isTaskButtonClone = true;
+
             if (this._sourceIndicator) {
                 // Check if the source indicator has any visible content
                 const sourceChild = this._sourceIndicator.get_first_child();
@@ -228,6 +238,38 @@ export const MirroredIndicatorButton = GObject.registerClass(
             this.can_focus = false;
             this.track_hover = false;
         }
+
+        // Per-monitor taskButton filter helpers
+        _isTaskButtonRole(role) {
+            // tasks-in-panel format: `taskButton${windowId}`, windowId is a positive int.
+            // Strict regex so future roles like 'taskButtonGroup' don't produce false positives.
+            return typeof role === 'string' && /^taskButton\d+$/.test(role);
+        }
+
+        _getTaskButtonWindow() {
+            // TaskButton._window is set BEFORE addToStatusArea, so _window is populated while the clone is visible.
+            const src = this._sourceIndicator;
+            if (!src)
+                return null;
+            const win = src._window;
+            return (win && typeof win.get_monitor === 'function') ? win : null;
+        }
+
+        _shouldShowTaskButton() {
+            const win = this._getTaskButtonWindow();
+            if (!win)
+                return false;                    // no/dangling _window -> safe default: hide
+            let mon = -1;
+            try {
+                mon = win.get_monitor();         // dangling Meta.Window guard
+            } catch (_e) {
+                return false;
+            }
+            if (mon < 0)
+                return false;                    // monitor not assigned yet (transition moment)
+            return mon === this._panel.monitorIndex; // this._panel.monitorIndex
+        }
+        // end of filter helpers
 
         _setupSourcePresenceWatchers() {
             if (this._sourcePresenceWatched)
@@ -271,6 +313,13 @@ export const MirroredIndicatorButton = GObject.registerClass(
                 this._markEmpty();
                 return;
             }
+
+            // FILTER-B guard: taskButton visibility is owned ONLY by _syncTaskbarFilter
+            // (window-entered/left-monitor -> all panels). _syncMirrorPresence is triggered by source-
+            // allocation spam; during a drag it could read the get_monitor()=-1 transition moment and hide
+            // the clone incorrectly. Do NOT touch taskButton clones here -> the race is resolved.
+            if (this._isTaskButtonClone)
+                return;
 
             const sourceChild = this._sourceIndicator.get_first_child?.();
             const hasContent = this._sourceIndicator.visible &&
@@ -1217,7 +1266,16 @@ export const MirroredIndicatorButton = GObject.registerClass(
             const forwardSpec = (eventName, vfuncName, event) => {
                 let handled = false;
 
-                if ((eventName === 'button-press-event' || eventName === 'touch-event') && (targetChild.menu || targetChild._menu)) {
+                // BUG FIX (taskButton left-click behavior): the Astra Monitor menu-opening workaround is ONLY
+                // for menu-centric indicators (like Astra). A tasks-in-panel TaskButton handles a left-click
+                // PanelMenu.Button (default bos .menu var) ama tiklamayi button-RELEASE ile
+                // as window-activate/minimize (its own _onClick).
+                // On a taskButton clone this workaround wrongly opened a menu on button-PRESS -> left-click
+                // showed "right-click-like options". SKIP it for taskButton clones -> the normal forward below
+                // runs tasks-in-panel's own left/right behavior (same as on the primary).
+                if ((eventName === 'button-press-event' || eventName === 'touch-event')
+                    && !this._isTaskButtonClone
+                    && (targetChild.menu || targetChild._menu)) {
                     if (this._openAstraProxyMenu(proxy, targetChild)) {
                         return Clutter.EVENT_STOP;
                     }
@@ -2106,6 +2164,29 @@ export const MirroredIndicatorButton = GObject.registerClass(
 
             if (this._role === 'quickSettings' && this._sourceIndicator?.menu) {
                 return this._openQuickSettingsMenu();
+            }
+
+            // BUG FIX (taskButton clone left-click = SAME behavior as on the primary):
+            // The clone goes through its own PanelMenu.Button _onButtonPress (not the Astra forwardSpec — a
+            // taskButton never enters that path). Since the source TaskButton's AppMenu is populated, the
+            // (this._sourceIndicator.menu) HER tikta menuyu aciyordu → sol-tik "sag-tik gibi options".
+            // tasks-in-panel primary'de menu-on-press'i vfunc_event no-op ile oldurur ve button-RELEASE'te
+            // generic branch below would do left=activate/right=menu. We reproduce that per-button on the clone:
+            //   left   -> source _toggleWindow() (activate/minimize the window)
+            //   middle -> source _onClick(event) (new window)
+            //   right  -> fall through -> _openMirroredMenu (source AppMenu anchored to the clone = primary right-click)
+            if (this._isTaskButtonClone) {
+                const src = this._sourceIndicator;
+                const button = event?.get_button?.() ?? Clutter.BUTTON_PRIMARY;
+                if (button === Clutter.BUTTON_PRIMARY && src && typeof src._toggleWindow === 'function') {
+                    src._toggleWindow();
+                    return Clutter.EVENT_STOP;
+                }
+                if (button === Clutter.BUTTON_MIDDLE && src && typeof src._onClick === 'function') {
+                    src._onClick(event);
+                    return Clutter.EVENT_STOP;
+                }
+                // SECONDARY (right) -> fall through to _openMirroredMenu below (source AppMenu)
             }
 
             // Check for standard menu first

--- a/mmpanel.js
+++ b/mmpanel.js
@@ -33,6 +33,9 @@ import * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import * as MultiMonitors from './extension.js';
+
+// Per-monitor taskButton filtering debug-log flag.
+const MMB_PM_DEBUG = false;
 import * as MMCalendar from './mmcalendar.js';
 import * as Constants from './mmPanelConstants.js';
 import { StatusIndicatorsController } from './statusIndicatorsController.js';
@@ -425,6 +428,26 @@ const MultiMonitorsPanel = GObject.registerClass(
 
             this._workareasChangedId = global.display.connect('workareas-changed', () => this.queue_relayout());
 
+            // FILTER-B: window monitor change -> taskbar re-filter
+            // tasks-in-panel does NOT listen for monitor changes, so this watcher is required.
+            // connectObject(owner=this) → panel destroy'da otomatik disconnect (leak-proof,
+            // mevcut disposed-error baseline'ini cogaltmaz).
+            global.display.connectObject(
+                'window-entered-monitor', (_d, idx, win) => this._onWindowMonitorChanged(idx, win),
+                'window-left-monitor', (_d, idx, win) => this._onWindowMonitorChanged(idx, win),
+                // restacked: after a window's stacking/monitor transition settles -> idempotent re-filter
+                // (window-list/aztaskbar listen to the same signal; cheap thanks to the no-op guard).
+                'restacked', () => this._scheduleTaskbarFilterSync(),
+                // grab-op-end: a final re-sync guarantee at the end of a drag (even if a signal is missed).
+                'grab-op-end', () => this._scheduleTaskbarFilterSync(),
+                this);
+
+            // ROOT CAUSE #3 FIX: deferred-work (GNOME-native). _scheduleTaskbarFilterSync no longer uses a
+            // GLib trailing-timeout but Main.queueDeferredWork -> it runs once BEFORE the next frame,
+            // automatically coalescing the drag's signal burst with zero lag. The old 100ms
+            // trailing-debounce never fired until the drag ENDED (the fast-drag bug).
+            this._taskbarFilterWorkId = Main.initializeDeferredWork(this, () => this._syncTaskbarFilter());
+
             this._showActivitiesId = this._settings.connect('changed::' + SHOW_ACTIVITIES_ID,
                 this._showActivities.bind(this));
             this._showActivities();
@@ -554,6 +577,10 @@ const MultiMonitorsPanel = GObject.registerClass(
                     GLib.source_remove(timeoutId);
                 this._panelRefreshTimeouts = [];
             }
+            // The FILTER-B deferred-work (this._taskbarFilterWorkId) is cleaned up automatically by Main
+            // on panel destroy (initializeDeferredWork hooks the actor's 'destroy' signal), so no
+            // manual source_remove is needed. The old GLib trailing-timeout was removed.
+            this._taskbarFilterWorkId = null;
 
             if (this._clickGestureRecognizeId && this._clickGesture) {
                 this._clickGesture.disconnect(this._clickGestureRecognizeId);
@@ -1169,6 +1196,20 @@ const MultiMonitorsPanel = GObject.registerClass(
                 this._removeRole(rightIndicators, 'activities');
             }
 
+            // BUG FIX (show-activities ayari extended panelde de onurlanir):
+            // MMB's synthetic Activities (workspace-dots) button is recreated on every _updatePanel via
+            // HER _updatePanel'de yeniden yaratiliyordu. _showActivities (mmpanel:612) ayari onurlandirir
+            // ama bu clone pipeline SHOW_ACTIVITIES_ID gate'ini yok sayip onu yeniden yaratiyordu →
+            // _ensureIndicator('activities'), so show-activities=false had no effect. Fix (same pattern as
+            // ayar kapaliysa 'activities' rolunu listelerden cikar → desiredRoles disi kalir →
+            // _removeStaleIndicators temizler, _updateBox yeniden yaratmaz.
+            // the ArcMenu drop, no deletion). (Independent MMB bug — does NOT touch the taskButton filters.)
+            if (!this._settings.get_boolean(SHOW_ACTIVITIES_ID)) {
+                this._removeRole(leftIndicators, 'activities');
+                this._removeRole(centerIndicators, 'activities');
+                this._removeRole(rightIndicators, 'activities');
+            }
+
             // Now mirror them in order
             const desiredRoles = new Set([...leftIndicators, ...centerIndicators, ...rightIndicators]);
             this._removeStaleIndicators(desiredRoles);
@@ -1176,7 +1217,71 @@ const MultiMonitorsPanel = GObject.registerClass(
             this._updateBox(leftIndicators, this._leftBox);
             this._updateBox(centerIndicators, this._centerBox);
             this._updateBox(rightIndicators, this._rightBox);
+            this._syncTaskbarFilter();   // taskbar per-monitor filter after re-scan (FILTER-B)
         }
+
+        // FILTER-B: dynamic taskbar filtering methods
+        _onWindowMonitorChanged(monitorIndex, metaWin) {
+            // The monitorIndex guard was REMOVED: every panel re-syncs on EVERY monitor event.
+            // Even if the window-entered(target) signal is missed/reordered during a fast drag, on any
+            // incoming window-left/entered event ALL panels recompute the absolute state
+            // (idempotent + cheap no-op guard). Robust against missed-signal/ordering races.
+            const t = metaWin?.get_window_type?.();
+            if (t === Meta.WindowType.NORMAL || t === Meta.WindowType.DIALOG ||
+                t === Meta.WindowType.MODAL_DIALOG || t === Meta.WindowType.SPLASHSCREEN)
+                this._scheduleTaskbarFilterSync();
+        }
+
+        _scheduleTaskbarFilterSync() {
+            // DEFERRED-WORK coalescing (ROOT CAUSE #3 FIX). _syncTaskbarFilter runs once before the
+            // next frame; a drag's signal burst is coalesced automatically, with zero lag.
+            // queueDeferredWork only runs while the actor is MAPPED -> no wasted work while the panel is hidden.
+            if (this._taskbarFilterWorkId)
+                Main.queueDeferredWork(this._taskbarFilterWorkId);
+        }
+
+        _syncTaskbarFilter() {
+            // IDEMPOTENT — every call recomputes the absolute state from scratch (not a toggle/delta).
+            //
+            // ROOT CAUSE #1 FIX: shouldShow no longer DEPENDS on the source taskButton's `.visible`.
+            // Eski kod `&& !!src.visible` kullaniyordu. Ama PrimaryTaskbarFilter (extension.js) primary-
+            // The old code used `&& !!src.visible`, but PrimaryTaskbarFilter (extension.js) sets the REAL
+            // Main.panel taskButton.visible to false for non-primary windows; that factor carried the
+            // gorunmuyordu. window-list/aztaskbar kanonik pattern'i: kaynagin gorunurlugunu DEGIL,
+            // hiding into the extended clones too. Compute the window's own state (skip_taskbar + active
+            const myMonitor = this.monitorIndex;
+            const activeWs = global.workspace_manager.get_active_workspace();
+            let changed = 0;
+            // Object.keys snapshot — so a statusArea mutation during iteration (clone
+            // add/remove) can't crash (edge: window close + re-filter race).
+            for (const role of Object.keys(this.statusArea)) {
+                if (!/^taskButton\d+$/.test(role))
+                    continue;
+                const clone = this.statusArea[role];
+                if (!clone)
+                    continue;
+                const win = clone._sourceIndicator?._window;
+                let shouldShow = false;
+                try {
+                    shouldShow = !!win
+                        && !win.skip_taskbar
+                        && win.located_on_workspace(activeWs)
+                        && win.get_monitor() === myMonitor;
+                } catch (_e) {
+                    shouldShow = false;   // dangling Meta.Window -> hide
+                }
+                if (shouldShow === clone.visible)
+                    continue;   // NO-OP guard (visible-based; _isEmpty'e dokunma → box'ta kalir)
+                clone.visible = shouldShow;
+                clone.reactive = shouldShow;
+                clone.can_focus = shouldShow;
+                clone.track_hover = shouldShow;
+                changed++;
+            }
+            if (MMB_PM_DEBUG && changed)
+                log(`[MMB-FILTER] sync panel=${myMonitor} changed=${changed}`);
+        }
+        // end of FILTER-B methods
 
         _isArcMenuRole(role) {
             if (role !== 'ArcMenu')


### PR DESCRIPTION
Fresh PR on top of current `main` (98e57df), as requested in #36 — the previous PR was
against an older `main`, so this re-bases the same work onto your latest updates. Continues
the discussion in #35.

## Summary

Adds **per-monitor taskbar filtering** so a third-party taskbar mirrored by MMB
([Tasks in panel](https://github.com/fthx/tasks-in-panel) by @fthx) shows **only the windows
that live on each monitor**, instead of every monitor mirroring the same global window list
(#35). Also fixes a small independent baseline bug: the synthetic Activities button was
recreated on extended panels even when `show-activities` was off.

## What changed

Three cooperating, idempotent filters using the canonical `window-list` / `aztaskbar`
primitive — visibility is computed from the **window's own state**, never from the source
button's `.visible`:

```
shouldShow = !win.skip_taskbar
          && win.located_on_workspace(active)
          && win.get_monitor() === panelMonitor
```

- **`mmpanel.js` — `_syncTaskbarFilter()`**: per-extended-panel sweep over `taskButton` clones,
  scheduled via **`Main.queueDeferredWork`** (next-frame coalescing, zero lag) on
  `window-entered/left-monitor`, `restacked`, `grab-op-end`.
- **`mirroredIndicatorButton.js` — FILTER-A/B**: flags taskButton clones and keeps
  `_syncMirrorPresence` from fighting the per-monitor filter.
- **`extension.js` — `PrimaryTaskbarFilter`**: the same rule for the real `Main.panel`
  taskButtons on the primary monitor (idempotent, `notify::visible` recursion-safe).
- **Left-click parity**: a taskButton clone's left-click reaches Tasks in panel's own
  activate/minimize handler instead of the generic mirrored-menu path.

It filters MMB's mirrored `taskButton` clones generically, so it applies to any taskbar MMB
mirrors, **without modifying the other extension**.

### Independent fix: honor `show-activities` on extended panels
`_ensureIndicator('activities')` recreated the synthetic Activities button on every
`_updatePanel`, bypassing the `show-activities` gate. Added a one-line guard (same pattern as
the existing ArcMenu activities-drop).

## Status / testing

Marked as **draft**: the original work was developed and tested on **GNOME Shell 49.4 /
Wayland / Fedora 43 / 4 monitors (DisplayLink)**, and this commit has been **ported onto your
current `main` (98e57df)** — 2 of 3 files applied cleanly (3-way), `extension.js` had one
trivial keep-both conflict (your dash-to-dock consts + the new filter class). `node --check`
passes on all three.

It still needs a **runtime verification pass on current `main` (GNOME 50)** on a real
multi-monitor rig before I'd call it merge-ready — I'll flip it to "ready for review" once I've
re-tested on my GNOME 50 setup. Flagging now so you can review the approach/diff. Happy to add
a prefs toggle (default off) or a guard that skips mirror-filtering a taskbar that already does
its own per-monitor placement (avoids double panels when both run on GNOME 50) — your call.
