### PR TITLE
fix: indicator transfers never applied at login; panel rebuild ignores per-button settings

### DIFF
--- a/mmPanelConstants.js
+++ b/mmPanelConstants.js
@@ -28,11 +28,6 @@ export const EXCLUDE_INDICATORS_ID = 'exclude-indicators';
 // Store reference to mmPanel array set by extension.js
 let _mmPanelArrayRef = null;
 
-// Helper function to set the mmPanel reference
-export function setMMPanelArrayRef(mmPanelArray) {
-	_mmPanelArrayRef = mmPanelArray;
-}
-
 // Panels that registered themselves at construction. _pushPanel() adds panels
 // to whichever array the reference happens to point at, which has proven
 // unreliable at session start: the panels exist and render while the shared
@@ -40,6 +35,24 @@ export function setMMPanelArrayRef(mmPanelArray) {
 // and every indicator transfer silently no-ops. Self-registration does not
 // depend on the reference being set first.
 const _registeredPanels = [];
+
+// Helper function to set the mmPanel reference
+export function setMMPanelArrayRef(mmPanelArray) {
+	_mmPanelArrayRef = mmPanelArray;
+
+	// enable() clears the shared array immediately before setting the
+	// reference, so any panel registered before that point would be dropped
+	// from it. Backfill, or callers that read the array directly - the
+	// Blur my Shell registration and the relayout loop in mmlayout - see no
+	// panels even though they exist.
+	if (!_mmPanelArrayRef)
+		return;
+
+	for (const panel of _registeredPanels) {
+		if (!_mmPanelArrayRef.includes(panel))
+			_mmPanelArrayRef.push(panel);
+	}
+}
 
 export function registerMMPanel(panel) {
 	if (!_registeredPanels.includes(panel))

--- a/mmPanelConstants.js
+++ b/mmPanelConstants.js
@@ -33,12 +33,47 @@ export function setMMPanelArrayRef(mmPanelArray) {
 	_mmPanelArrayRef = mmPanelArray;
 }
 
+// Panels that registered themselves at construction. _pushPanel() adds panels
+// to whichever array the reference happens to point at, which has proven
+// unreliable at session start: the panels exist and render while the shared
+// array stays empty, so StatusIndicatorsController._findPanel() finds nothing
+// and every indicator transfer silently no-ops. Self-registration does not
+// depend on the reference being set first.
+const _registeredPanels = [];
+
+export function registerMMPanel(panel) {
+	if (!_registeredPanels.includes(panel))
+		_registeredPanels.push(panel);
+
+	// Keep the shared array in step when it is available, so callers reading it
+	// directly see the panel too.
+	if (_mmPanelArrayRef && !_mmPanelArrayRef.includes(panel))
+		_mmPanelArrayRef.push(panel);
+}
+
+export function unregisterMMPanel(panel) {
+	const localIndex = _registeredPanels.indexOf(panel);
+	if (localIndex >= 0)
+		_registeredPanels.splice(localIndex, 1);
+
+	if (_mmPanelArrayRef) {
+		const sharedIndex = _mmPanelArrayRef.indexOf(panel);
+		if (sharedIndex >= 0)
+			_mmPanelArrayRef.splice(sharedIndex, 1);
+	}
+}
+
 // Helper function to safely access mmPanel array
 export function getMMPanelArray() {
 	// First try Main.mmPanel if it exists
 	if ('mmPanel' in Main && Main.mmPanel) {
 		return Main.mmPanel;
 	}
-	// Fall back to stored reference
-	return _mmPanelArrayRef;
+	// Then the reference set by extension.js, but only when it actually holds
+	// panels - an empty one means registration went astray.
+	if (_mmPanelArrayRef && _mmPanelArrayRef.length > 0) {
+		return _mmPanelArrayRef;
+	}
+	// Fall back to panels that registered themselves.
+	return _registeredPanels;
 }

--- a/mmpanel.js
+++ b/mmpanel.js
@@ -1078,6 +1078,12 @@ const MultiMonitorsPanel = GObject.registerClass(
                 return;
             }
 
+            // Queued callbacks can outlive the panel on monitor unplug, and
+            // _cleanup() nulls the settings it owns.
+            if (!this._settings) {
+                return;
+            }
+
             // Indicators that should NOT be mirrored (system/accessibility indicators and GNOME 46 phantom indicators)
             const excludedIndicators = [
                 'a11y',              // Accessibility menu

--- a/mmpanel.js
+++ b/mmpanel.js
@@ -1175,6 +1175,26 @@ const MultiMonitorsPanel = GObject.registerClass(
                 this._removeRole(rightIndicators, 'activities');
             }
 
+            // The per-button settings are authoritative for these roles, so the
+            // clone pass has to honour them as well. Otherwise any re-clone -
+            // and one runs whenever *another* extension is enabled or disabled -
+            // rebuilds a button the user switched off, and nothing puts it back
+            // until the setting is toggled again.
+            const legacyRoleSettings = {
+                'activities': SHOW_ACTIVITIES_ID,
+                'appMenu': SHOW_APP_MENU_ID,
+                'dateMenu': SHOW_DATE_TIME_ID,
+            };
+            for (const [legacyRole, settingKey] of Object.entries(legacyRoleSettings)) {
+                if (this._settings.get_boolean(settingKey))
+                    continue;
+
+                this._removeRole(leftIndicators, legacyRole);
+                this._removeRole(centerIndicators, legacyRole);
+                this._removeRole(rightIndicators, legacyRole);
+            }
+
+
             // Now mirror them in order
             const desiredRoles = new Set([...leftIndicators, ...centerIndicators, ...rightIndicators]);
             this._removeStaleIndicators(desiredRoles);

--- a/mmpanel.js
+++ b/mmpanel.js
@@ -338,6 +338,10 @@ const MultiMonitorsPanel = GObject.registerClass(
             this.monitorIndex = monitorIndex;
             this._settings = settings;
 
+            // Register before anything else can fail: _findPanel() depends on
+            // this to route indicator transfers to the right panel.
+            Constants.registerMMPanel(this);
+
             this._destroyed = false;
             // Cleanup MUST run from the `destroy` SIGNAL, not only the destroy()
             // method. On resume from sleep a monitor can disappear and mutter
@@ -528,6 +532,8 @@ const MultiMonitorsPanel = GObject.registerClass(
         _cleanup() {
             if (this._destroyed)
                 return;
+
+            Constants.unregisterMMPanel(this);
             this._destroyed = true;
 
             // Clean up extension watcher


### PR DESCRIPTION
Three independent fixes to indicator transfer and panel rebuild. No new
settings, no UI changes. Each commit stands alone.

Tested on GNOME 46, Wayland, two monitors (DP-3 primary, HDMI-1 secondary).

---

### 1. Indicators configured for a secondary panel stay on the primary after login

**Symptom:** set an indicator to transfer to a secondary monitor, log out
and back in, and it stays on the primary. Applying the same setting
mid-session works, which makes it look intermittent.

`_pushPanel()` registers the panel with:

```js
const mmPanelRef = getMMPanelArray();
if (mmPanelRef) {
    mmPanelRef.push(panel);
}
```

At session start that reference is not usable, so the push is skipped
silently. The panel itself is fine — `mmlayout` tracks it separately in
`this.mmPanelBox` — but it never lands in the shared array.

`StatusIndicatorsController._findPanel()` searches that array, finds
nothing, and the `&& panel` guard in `transferIndicators()` skips the
move without logging. I confirmed it with temporary instrumentation:
`panels=0`, `panelFound=false` on every call during login, while the
indicator's container was demonstrably in `Main.panel._rightBox`.

**Fix:** panels register themselves at construction and unregister in
`_cleanup()`, so the lookup no longer depends on the reference being set
first. `getMMPanelArray()` also treats an empty shared array as a failed
registration and falls back to the self-registered list.

### 2. Activities/DateTime reappear on secondary panels after switching them off

**Symptom:** turn off "Show Activities-Button on additional monitors",
then enable or disable *any unrelated extension*. The button comes back
and stays until the setting is toggled again.

`_cloneAllMainPanelIndicators()` rebuilds from whatever is on
`Main.panel` without consulting `show-activities`, `show-app-menu` or
`show-date-time`. Any re-clone therefore resurrects a button the user
switched off — and `extension-state-changed` triggers one, so an
unrelated extension loading is enough. Session-mode updates and geometry
changes do it too.

**Fix:** the clone pass drops those roles when their setting is off.
`_removeStaleIndicators()` then destroys any existing one, so this also
corrects a button that is already wrongly showing.

Note: `vfunc_map()` re-asserts `_showDateTime()` immediately after
`_updatePanel()`, which looks like an earlier workaround for this same
race. It is now redundant, but I have left it alone — removing it is a
behaviour change worth making deliberately.

### 3. Clone pass can run against a panel being torn down

`_cleanup()` nulls the settings the panel owns, but callbacks queued
before it ran can still fire afterwards, leaving
`_cloneAllMainPanelIndicators()` working against a disposed panel and a
null `this._settings`.

**Fix:** bail out when the owned reference is gone.

---

Checked against `GUIDELINES.md`: no `log()`, no guarded calls on stable
API, no `_isDestroyed`-style guard flags, no try/catch around property
access or cleanup.
