### PR TITLE
fix: only rebuild mirrored indicator icons when the source changed

### DIFF
--- a/mirroredIndicatorButton.js
+++ b/mirroredIndicatorButton.js
@@ -1566,6 +1566,7 @@ export const MirroredIndicatorButton = GObject.registerClass(
                     GLib.source_remove(this._iconSyncId);
                     this._iconSyncId = null;
                 }
+                this._iconSyncSignature = null;
             });
         }
 
@@ -1911,16 +1912,58 @@ export const MirroredIndicatorButton = GObject.registerClass(
                 this._iconSyncId = null;
             }
 
-            // Full rebuild every 5 seconds to catch added/removed icons
+            // Poll every 5 seconds to catch added/removed icons, but only
+            // rebuild when the source tree actually changed. An unconditional
+            // rebuild destroys and recreates every mirrored icon, which shows
+            // up as a periodic flicker on the secondary panels.
             this._iconSyncId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 5, () => {
                 if (!this._iconContainer || !this._iconSource) {
                     this._iconSyncId = null;
+                    this._iconSyncSignature = null;
                     return GLib.SOURCE_REMOVE;
                 }
 
-                this._copyIconsFromSource(this._iconContainer, this._iconSource);
+                const signature = this._mirrorSourceSignature(this._iconSource);
+                if (signature !== this._iconSyncSignature) {
+                    this._iconSyncSignature = signature;
+                    this._copyIconsFromSource(this._iconContainer, this._iconSource);
+                }
+
                 return GLib.SOURCE_CONTINUE;
             });
+        }
+
+        // Structural fingerprint of the mirrored source: icon names/gicons,
+        // icon sizes, label texts, visibility and per-level child counts.
+        // Cheap enough to run on every poll and stable while nothing changes.
+        _mirrorSourceSignature(actor) {
+            const parts = [];
+
+            const walk = node => {
+                if (!node)
+                    return;
+
+                if (node.visible === false) {
+                    parts.push('h');
+                    return;
+                }
+
+                if (node instanceof St.Icon) {
+                    const id = node.icon_name || (node.gicon ? node.gicon.to_string() : '') || '';
+                    parts.push(`i:${id}:${node.icon_size || 0}`);
+                } else if (node instanceof St.Label) {
+                    parts.push(`l:${node.text || ''}`);
+                }
+
+                const children = node.get_children ? node.get_children() : [];
+                parts.push(`(${children.length}`);
+                for (const child of children)
+                    walk(child);
+                parts.push(')');
+            };
+
+            walk(actor);
+            return parts.join('|');
         }
 
         _createFillClone(parent, source) {
@@ -3191,6 +3234,7 @@ export const MirroredIndicatorButton = GObject.registerClass(
                 GLib.source_remove(this._iconSyncId);
                 this._iconSyncId = null;
             }
+            this._iconSyncSignature = null;
 
             if (this._arcMenuTimeoutId) {
                 GLib.source_remove(this._arcMenuTimeoutId);


### PR DESCRIPTION
## Problem

`MirroredIndicatorButton._startIconSync()` rebuilds the mirrored icon
container unconditionally every 5 seconds:

```js
// Full rebuild every 5 seconds to catch added/removed icons
this._iconSyncId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 5, () => {
    ...
    this._copyIconsFromSource(this._iconContainer, this._iconSource);
    return GLib.SOURCE_CONTINUE;
});
```

`_copyIconsFromSource()` starts with `container.remove_all_children()` and
then recreates every icon copy from scratch. Since this runs on a timer
rather than in response to an actual change, all mirrored status icons are
destroyed and rebuilt every 5 seconds even when nothing changed.

On the secondary panel this is clearly visible as a short flicker of the
whole status area, at a steady 5 second interval. The mirrored clock does
not flicker because it goes through a separate code path, which makes the
effect look even more out of place.

## Change

Keep the 5 second poll, but only rebuild when the source actually changed.

`_mirrorSourceSignature()` walks the source actor tree and builds a cheap
structural fingerprint from:

- icon names, or the GIcon string when there is no icon name
- icon sizes
- label texts
- visibility
- per-level child counts

The poll compares the fingerprint against the previous one and calls
`_copyIconsFromSource()` only on a mismatch. Added, removed or changed
icons are still picked up on the next tick, so the original purpose of the
timer is preserved.

`_iconSyncSignature` is reset next to `_iconSyncId` in every cleanup path
(source `destroy` handler, `_startIconSync()` re-entry, `_cleanup()`) so no
stale fingerprint survives a monitor change or a source swap.

## Notes on style

Following `GUIDELINES.md`, the new code contains no defensive `try`/`catch`
around the tree walk or around `gicon.to_string()`. `g_icon_to_string()`
returns `null` for non-serializable icons rather than throwing, and that
case is handled by the fallback chain.

## Testing

GNOME Shell 50.1, Ubuntu 26.04, Wayland, two monitors (built-in 1920x1080
plus external 3440x1440, external as primary), extension version 48.

- Before: mirrored status icons flicker every 5 seconds on the secondary
  panel, reproducible with the stock Ubuntu appindicators.
- After: no flicker, status area is stable.
- Adding and removing tray icons while the panel is mirrored still updates
  the secondary panel within one poll interval.
